### PR TITLE
Harmonize ACR design with core abstraction updates

### DIFF
--- a/registry.rst
+++ b/registry.rst
@@ -381,7 +381,7 @@ Revision History
   * `v3 <https://github.com/agentos-project/design_docs/blob/e32ff7a96eab3486a3c8bb65c1ca1df280e20434/registry.rst>`_
   * `v4 <https://github.com/agentos-project/design_docs/blob/507bfb96a1b40bef8338603a3e661681d0d622c7/registry.rst>`_
   * `v5 <https://github.com/agentos-project/design_docs/blob/886f5a0eb960c398cc57d7cd5ec97956c528cca4/registry.rst>`_
-  * `v6 <https://github.com/agentos-project/design_docs/blob/TODO/registry.rst>`_
+  * `v6 <https://github.com/agentos-project/design_docs/blob/2ec8b7f231330119d153a24725537a7c4e71084d/registry.rst>`_
 
     * Rename AgentOS Component System (ACS) to AgentOS Component Registry (ACR)
 

--- a/registry.rst
+++ b/registry.rst
@@ -369,6 +369,10 @@ TODO and open questions
 Revision History
 ================
 
+* Discussion Thread:
+
+  * `AgentOS Component Registry <https://github.com/agentos-project/design_docs/discussions/7>`_
+
 * Pull requests:
 
   * `design_docs #1: AgentOS registry <https://github.com/agentos-project/design_docs/pull/1>`_


### PR DESCRIPTION
v6 of the AgentOS component registry (ACR) design doc.  Harmonizes this doc with the discussions we've had over the past few days about core abstractions.

* [v6](https://github.com/nickjalbert/design_docs/blob/086ee1f658da51c7c7261ab898169f4b94ab6aff/registry.rst)


Changes in v6:

* Rename AgentOS Component System (ACS) to AgentOS Component Registry (ACR)
* Rename ``components.ini`` to ``agent.ini``
* Update demo to reflect core abstractions and new CLI
* Update FAQ to reflect recent discussions on core abstractions


